### PR TITLE
Bump version to 1.0.0a3 and fix passtype id parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "edutap.wallet-apple"
-version = "1.0.0a2"
+version = "1.0.0a3"
 description = "Library for Apple Wallet Communication"
 keywords = ["wallet", "apple", "api", "pass", 'fastapi', 'digital identity']
 readme = "README.md"

--- a/src/edutap/wallet_apple/settings.py
+++ b/src/edutap/wallet_apple/settings.py
@@ -65,7 +65,9 @@ class Settings(BaseSettings):
 
     def get_available_passtype_ids(self) -> list[str]:
         """List of available pass type identifiers"""
-        return [p.stem.split("-")[-1] for p in self.cert_dir.glob("certificate-*.pem")]
+        return [
+            p.stem.split("-", 1)[-1] for p in self.cert_dir.glob("certificate-*.pem")
+        ]
 
     def get_logger(self):
         """A Structlog based logger."""


### PR DESCRIPTION
## Summary
- Bump version from 1.0.0a2 to 1.0.0a3
- Fix passtype id parsing: use `split("-", 1)` instead of `split("-")` to handle passtype ids containing dashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)