### PR TITLE
Support new iOS 27 barcode formats (EAN-13, Code 39, Codabar, ITF)

### DIFF
--- a/src/edutap/wallet_apple/models/enums.py
+++ b/src/edutap/wallet_apple/models/enums.py
@@ -14,6 +14,11 @@ class BarcodeFormat(Enum):
     QR = "PKBarcodeFormatQR"
     AZTEC = "PKBarcodeFormatAztec"
     CODE128 = "PKBarcodeFormatCode128"
+    # requires iOS 27 or later
+    EAN13 = "PKBarcodeFormatEAN13"
+    CODE39 = "PKBarcodeFormatCode39"
+    CODABAR = "PKBarcodeFormatCodabar"
+    ITF = "PKBarcodeFormatITF"
 
 
 class TransitType(Enum):

--- a/src/edutap/wallet_apple/models/passes.py
+++ b/src/edutap/wallet_apple/models/passes.py
@@ -506,7 +506,7 @@ class Pass(BaseModel):
         if legacyBarcode is None:
             return None
 
-        if legacyBarcode not in original_formats:
+        if legacyBarcode.format not in original_formats:
             legacyBarcode = Barcode(
                 message=legacyBarcode.message,
                 format=BarcodeFormat.PDF417,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -174,6 +174,18 @@ def test_code128_pass():
     assert thawedJson["barcodes"][0]["format"] == BarcodeFormat.CODE128.value
 
 
+def test_qr_pass_keeps_legacy_format():
+    """
+    QR is a legacy-capable barcode format, so the legacy barcode
+    field must keep the QR format instead of falling back to PDF417.
+    """
+    passobject = create_shell_pass(BarcodeFormat.QR).pass_object
+    jsonData = passobject.model_dump_json()
+    thawedJson = json.loads(jsonData)
+    assert thawedJson["barcode"]["format"] == BarcodeFormat.QR.value
+    assert thawedJson["barcodes"][0]["format"] == BarcodeFormat.QR.value
+
+
 def test_pdf_417_pass():
     """
     This test is to create a pass with a barcode that is valid

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4,6 +4,7 @@ from edutap.wallet_apple.models.passes import BarcodeFormat
 
 import conftest as conftest
 import json
+import pytest
 
 
 def test_model():
@@ -196,6 +197,34 @@ def test_pdf_417_pass():
     thawedJson = json.loads(jsonData)
     assert thawedJson["barcode"]["format"] == BarcodeFormat.PDF417.value
     assert thawedJson["barcodes"][0]["format"] == BarcodeFormat.PDF417.value
+
+
+@pytest.mark.parametrize(
+    "fmt,expected",
+    [
+        ("EAN13", "PKBarcodeFormatEAN13"),
+        ("CODE39", "PKBarcodeFormatCode39"),
+        ("CODABAR", "PKBarcodeFormatCodabar"),
+        ("ITF", "PKBarcodeFormatITF"),
+    ],
+)
+def test_ios27_barcode_formats(fmt, expected):
+    """
+    iOS 27 adds EAN-13, Code 39, Codabar and ITF barcode formats.
+    They serialize with their PKBarcodeFormat identifier, and the
+    legacy barcode field falls back to PDF417 since they are not
+    legacy-capable.
+    """
+    barcode_format = getattr(BarcodeFormat, fmt)
+    assert barcode_format.value == expected
+
+    passobject = create_shell_pass(barcodeFormat=barcode_format).pass_object
+    thawedJson = json.loads(passobject.model_dump_json())
+    assert thawedJson["barcodes"][0]["format"] == expected
+    assert thawedJson["barcode"]["format"] == BarcodeFormat.PDF417.value
+
+    roundtripped = passes.Pass.from_json(passobject.model_dump_json(exclude_none=True))
+    assert roundtripped.barcodes[0].format == barcode_format
 
 
 def test_files():


### PR DESCRIPTION
Fixes #31

## Changes

- **feat:** Extend `BarcodeFormat` with the four barcode formats added in iOS 27 (WWDC 2026): `PKBarcodeFormatEAN13`, `PKBarcodeFormatCode39`, `PKBarcodeFormatCodabar`, `PKBarcodeFormatITF`.
- **fix:** The deprecated legacy `barcode` computed field compared the `Barcode` object itself against the list of legacy `BarcodeFormat` values — always false, so even legacy-capable QR/Aztec barcodes were downgraded to PDF417. It now compares the barcode's `format`. The new iOS 27 formats are not legacy-capable and correctly keep falling back to PDF417.

## Tests

- New parametrized test covering the four formats: enum value, serialization, legacy fallback to PDF417, and JSON round-trip.
- New regression test that a QR barcode keeps its format in the legacy `barcode` field.
- Full suite: 48 passed, 24 skipped; `tox -e lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)