### PR TITLE
Support new iOS 27 featuredActions top-level pass key

### DIFF
--- a/src/edutap/wallet_apple/models/passes.py
+++ b/src/edutap/wallet_apple/models/passes.py
@@ -295,6 +295,19 @@ class Barcode(BaseModel):
     altText: str = ""  # Optional. Text displayed near the barcode
 
 
+class FeaturedAction(BaseModel):
+    """
+    An action displayed as a tappable tile under the pass face.
+    Requires iOS 27 or later.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    identifier: str  # Required. A unique identifier for the action
+    type: str  # Required. The action type, for example "membershipBenefits"
+    url: str  # Required. The universal link the action opens
+
+
 IBeacon = Beacon  # Alias for backward compatibility
 
 
@@ -594,6 +607,15 @@ class Pass(BaseModel):
     Optional. string
     The date and time the pass expires.
     The value needs to be a complete date that includes hours and minutes, and may optionally include seconds.
+    """
+
+    featuredActions: list[FeaturedAction] | None = pydantic.Field(
+        default=None, max_length=2
+    )
+    """
+    Optional.
+    Up to two actions to display as tappable tiles under the pass face, in priority order.
+    Requires iOS 27 or later.
     """
 
     footerBackgroundColor: str | None = None

--- a/src/edutap/wallet_apple/models/passes.py
+++ b/src/edutap/wallet_apple/models/passes.py
@@ -299,6 +299,11 @@ class FeaturedAction(BaseModel):
     """
     An action displayed as a tappable tile under the pass face.
     Requires iOS 27 or later.
+
+    No reference page exists yet at
+    https://developer.apple.com/documentation/walletpasses (iOS 27 beta),
+    see https://developer.apple.com/videos/play/wwdc2026/209/ and
+    https://developer.apple.com/wallet/whats-new/ instead.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -615,7 +620,7 @@ class Pass(BaseModel):
     """
     Optional.
     Up to two actions to display as tappable tiles under the pass face, in priority order.
-    Requires iOS 27 or later.
+    Requires iOS 27 or later, see FeaturedAction for references.
     """
 
     footerBackgroundColor: str | None = None

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4,6 +4,7 @@ from edutap.wallet_apple.models.passes import BarcodeFormat
 
 import conftest as conftest
 import json
+import pydantic
 import pytest
 
 
@@ -225,6 +226,46 @@ def test_ios27_barcode_formats(fmt, expected):
 
     roundtripped = passes.Pass.from_json(passobject.model_dump_json(exclude_none=True))
     assert roundtripped.barcodes[0].format == barcode_format
+
+
+def test_featured_actions():
+    """
+    iOS 27 adds the top-level featuredActions key: up to two tappable
+    actions in priority order, each with identifier, type and url.
+    """
+    passobject = create_shell_pass().pass_object
+    passobject.featuredActions = [
+        passes.FeaturedAction(
+            identifier="offers",
+            type="membershipBenefits",
+            url="https://example.com/offers",
+        )
+    ]
+    dumped = passobject.model_dump(exclude_none=True)
+    assert dumped["featuredActions"][0]["identifier"] == "offers"
+    assert dumped["featuredActions"][0]["type"] == "membershipBenefits"
+    assert dumped["featuredActions"][0]["url"] == "https://example.com/offers"
+
+    roundtripped = passes.Pass.from_json(passobject.model_dump_json(exclude_none=True))
+    assert roundtripped.featuredActions == passobject.featuredActions
+
+
+def test_featured_actions_allows_at_most_two():
+    action = {
+        "identifier": "offers",
+        "type": "membershipBenefits",
+        "url": "https://example.com/offers",
+    }
+    with pytest.raises(pydantic.ValidationError):
+        passes.Pass(
+            storeCard=passes.StoreCard(),
+            organizationName="Org Name",
+            passTypeIdentifier=conftest.PASS_TYPE_IDENTIFIER,
+            teamIdentifier="Team Identifier",
+            serialNumber="1234567",
+            description="A Sample Pass",
+            featuredActions=[action, action, action],
+        )
 
 
 def test_files():


### PR DESCRIPTION
Fixes #32

## Changes

- New `FeaturedAction` model (`identifier`, `type`, `url`) with `extra="forbid"`, consistent with the other pass models. `type` is modelled as plain `str` for now since Apple's stable reference docs don't yet list the closed set of action types (iOS 27 is still in beta).
- New optional `featuredActions` field on `Pass` (inserted in Apple's documented attribute order), validated to at most 2 entries as specified by Apple.

## Tests

- Round-trip test: construct, dump with `exclude_none`, re-parse via `Pass.from_json`, compare.
- Validation test: three actions raise a `pydantic.ValidationError`.
- Full suite: 45 passed, 24 skipped; `tox -e lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)