### PR TITLE
Support new iOS 27 posterGeneric pass style

### DIFF
--- a/src/edutap/wallet_apple/models/passes.py
+++ b/src/edutap/wallet_apple/models/passes.py
@@ -437,6 +437,35 @@ class StoreCard(PassInformation):
     """
 
 
+@passmodel("posterGeneric")
+class PosterGeneric(PassInformation):
+    """
+    Generic pass with full-bleed background artwork. Requires iOS 27 or
+    later; ship it together with a generic fallback for older devices.
+
+    No reference page exists yet at
+    https://developer.apple.com/documentation/walletpasses (iOS 27 beta),
+    see https://developer.apple.com/videos/play/wwdc2026/209/ and
+    https://developer.apple.com/wallet/whats-new/ instead.
+    """
+
+    footerFields: typing.List[PassFieldContent | SemanticPassFieldContent] = (
+        pydantic.Field(default_factory=list)
+    )
+    """
+    Optional.
+    Fields to be displayed in the footer of the pass.
+    Only the first footer field is displayed.
+    """
+
+    def addFooterField(self, key, value, label, textAlignment=None):
+        self.footerFields.append(
+            PassFieldContent(
+                key=key, value=value, label=label, textAlignment=textAlignment
+            )
+        )
+
+
 class Pass(BaseModel):
     """
     Represents a pass object. This is the base class for all pass types.
@@ -865,12 +894,18 @@ class Pass(BaseModel):
 
     @property
     def pass_information(self):
-        """Returns the pass information object by checking all passmodel entries using all()"""
+        """Returns the pass information object by checking all passmodel entries.
+
+        Poster styles take precedence over their designed fallback type:
+        an iOS 27 poster pass ships e.g. posterGeneric together with a
+        generic fallback for older devices, and current devices display
+        the poster style.
+        """
+        names = sorted(
+            pass_model_registry, key=lambda name: not name.startswith("poster")
+        )
         return next(
-            filter(
-                lambda x: x is not None,
-                (map(lambda x: getattr(self, x), pass_model_registry)),
-            )
+            info for info in (getattr(self, name) for name in names) if info is not None
         )
 
     @classmethod

--- a/tests/data/jsons/poster_generic_pass.json
+++ b/tests/data/jsons/poster_generic_pass.json
@@ -1,0 +1,53 @@
+{
+    "description": "A Sample Poster Generic Pass",
+    "formatVersion": 1,
+    "organizationName": "Org Name",
+    "passTypeIdentifier": "pass.demo.lmu.de",
+    "serialNumber": "100006",
+    "teamIdentifier": "JG943677ZY",
+    "posterGeneric": {
+        "headerFields": [
+            {
+                "key": "memberID",
+                "label": "Guest No.",
+                "value": "102035"
+            }
+        ],
+        "primaryFields": [
+            {
+                "key": "name",
+                "value": "John Doe",
+                "label": "Name"
+            }
+        ],
+        "footerFields": [
+            {
+                "key": "membershipType",
+                "value": "Family Pass"
+            }
+        ]
+    },
+    "generic": {
+        "headerFields": [
+            {
+                "key": "memberID",
+                "label": "Guest No.",
+                "value": "102035"
+            }
+        ],
+        "primaryFields": [
+            {
+                "key": "name",
+                "value": "John Doe",
+                "label": "Name"
+            }
+        ]
+    },
+    "barcodes": [
+        {
+            "format": "PKBarcodeFormatQR",
+            "message": "102035",
+            "messageEncoding": "iso-8859-1"
+        }
+    ]
+}

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -59,6 +59,35 @@ def test_load_generic_pass():
     assert json_
 
 
+def test_load_poster_generic_pass():
+    """
+    iOS 27 poster generic passes ship the posterGeneric style key
+    together with a generic fallback for older devices. Both keys
+    must validate side by side, and pass_information returns the
+    poster style since that is what current devices display.
+    """
+    buf = open(conftest.jsons / "poster_generic_pass.json").read()
+    pass1 = passes.Pass.model_validate_json(buf)
+
+    assert pass1.posterGeneric is not None
+    assert pass1.generic is not None
+    assert pass1.pass_information.__class__ == passes.PosterGeneric
+    assert pass1.posterGeneric.footerFields[0].key == "membershipType"
+
+    json_ = pass1.model_dump(exclude_none=True)
+    assert "posterGeneric" in json_
+    assert "generic" in json_
+    assert json_["posterGeneric"]["footerFields"][0]["value"] == "Family Pass"
+
+
+def test_poster_generic_add_footer_field():
+    info = passes.PosterGeneric()
+    info.addFooterField("membershipType", "Family Pass", None)
+    dumped = info.model_dump(exclude_none=True)
+    assert dumped["footerFields"][0]["key"] == "membershipType"
+    assert dumped["footerFields"][0]["value"] == "Family Pass"
+
+
 def test_load_boarding_pass():
     buf = open(conftest.jsons / "boarding_pass.json").read()
     pass1 = passes.Pass.model_validate_json(buf)


### PR DESCRIPTION
Fixes #30

## Changes

- New `PosterGeneric` pass model registered as `@passmodel("posterGeneric")`, with `footerFields` (poster-only, hence on the subclass rather than `PassInformation`) and an `addFooterField` helper consistent with the other field helpers.
- `Pass.pass_information` now gives poster styles precedence over their designed fallback type. Apple recommends shipping `posterGeneric` together with a `generic` key for iOS ≤ 26, so two style keys are now legitimately present at once — current devices display the poster style, so that is what the property returns. Passes with a single style key behave exactly as before.
- New fixture `poster_generic_pass.json` with both style keys, following Apple's backward-compatibility recommendation.
- Docstring references point to the WWDC26 session and What's new in Wallet, since no dedicated reference page exists yet under developer.apple.com/documentation/walletpasses (iOS 27 beta) — same approach as #34.

## Tests

- Load/round-trip test for a dual-key poster pass: both keys validate side by side, `pass_information` returns `PosterGeneric`, dump preserves both keys and the footer field.
- `addFooterField` helper test.
- Full suite: 52 passed, 24 skipped; `tox -e lint` clean.

## Notes

- `preferredStyleSchemes` is untouched — it is still unclear whether Apple adds generic-related scheme values; can follow up once documented.
- No dedicated signing test with a background image: the `PkPass` file handling is name-agnostic (covered by existing tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)