### PR TITLE
fix: resolve merge conflict markers in passes.py

### DIFF
--- a/src/edutap/wallet_apple/models/passes.py
+++ b/src/edutap/wallet_apple/models/passes.py
@@ -654,12 +654,12 @@ class Pass(BaseModel):
     The value needs to be a complete date that includes hours and minutes, and may optionally include seconds.
     """
 
-<<<<<<< HEAD
     fidoProfile: FidoProfile | None = None
     """
     Optional.
     An object that contains the FIDO profile information for the pass.
-=======
+    """
+
     featuredActions: list[FeaturedAction] | None = pydantic.Field(
         default=None, max_length=2
     )
@@ -667,7 +667,6 @@ class Pass(BaseModel):
     Optional.
     Up to two actions to display as tappable tiles under the pass face, in priority order.
     Requires iOS 27 or later, see FeaturedAction for references.
->>>>>>> origin/main
     """
 
     footerBackgroundColor: str | None = None

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -341,4 +341,6 @@ def test_fido_profile_and_issuer_binding_data_models():
     assert dumped["fidoProfile"]["accountHash"] == "YWJjZA=="
     assert "keyHash" not in dumped["fidoProfile"]
     assert dumped["issuerBindingData"]["issuerBindingData"] == "c2ln"
-    assert str(dumped["issuerBindingData"]["learnMoreURL"]).startswith("https://example.com")
+    assert str(dumped["issuerBindingData"]["learnMoreURL"]).startswith(
+        "https://example.com"
+    )


### PR DESCRIPTION
Keep both the fidoProfile and featuredActions pass fields, each with its own docstring, and remove the unresolved <<<<<<< / ======= / >>>>>>> markers that were committed to main. The file did not compile under any Python version while the markers were present.